### PR TITLE
Update dependencies: security patches and compatibility improvements

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,14 +18,17 @@ jobs:
           [
             "3.10",
             "3.11",
+            "3.12",
+            "3.13",
           ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install Dependencies
         run: |
           make install

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,3 +1,3 @@
-Django==4.2.16
-djangorestframework==3.15.2
-drf-simple-apikey==2.0.1
+Django>=4.2.17,<6.0
+djangorestframework>=3.15.2
+drf-simple-apikey>=2.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,8 @@ classifiers =
 	Programming Language :: Python
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
+	Programming Language :: Python :: 3.12
+	Programming Language :: Python :: 3.13
 	Programming Language :: Python :: Implementation :: PyPy
 	Topic :: Software Development :: Libraries :: Python Modules
 
@@ -52,9 +54,9 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires = 
-	django >= 4.2
-	djangorestframework >= 3.14.0
-	cryptography >= 38.0.4
+	django >= 4.2.17,<6.0
+	djangorestframework >= 3.15.2
+	cryptography >= 43.0.0
 
 [options.extras_require]
 test = 
@@ -62,7 +64,7 @@ test =
 	coverage
 	pytest-django
 tooling = 
-	black == 22.3.0
+	black >= 24.0.0,<25.0
 	pylint
 	bump2version
 


### PR DESCRIPTION
- Updated critical dependencies: cryptography (38.0.4→43.0.0), Django (4.2→4.2.17,<6.0), DRF (3.14.0→3.15.2)
- Added Python 3.12 and 3.13 support, updated GitHub Actions to v4/v5 with pip caching
- Updated Black to >=24.0.0 and example requirements.txt to match new minimum versions

Fixes #92