### PR TITLE
Fix naming/docs links, add threat model & comparison docs, rewrite quickstart, fix packaging metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ Changelog
 - Changed: `request.auth` set by `APIKeyAuthentication` is now the `APIKey` instance
   instead of the raw key string, matching DRF's convention (e.g. `TokenAuthentication`).
 - Changed: Documentation theme updated to shadcn for a modern, professional appearance
+- Fixed: Removed the `__init__.py` deprecation warning that incorrectly told users of the
+  current `drf-simple-apikey` package to switch away from itself; fixed stale
+  `readthedocs.io` links (old package name) across README, CONTRIBUTING, and
+  `settings.py` to point at the canonical docs site
+- Added: [Threat Model](https://drf-api-key.koladev.xyz/docs/threat-model) documentation
+  covering the encrypted-vs-hashed storage trade-off, what a leaked `FERNET_SECRET`
+  exposes, and incident-response steps
+- Fixed: `SECURITY.md` no longer contains generic template placeholder content
+- Changed: Rewrote the quickstart into a full production-ready walkthrough (env-var
+  secret, key creation/hand-off, curl example, `request.user`/`request.auth`,
+  revocation, and a table of every 403 failure cause and why it's 403 not 401)
+- Added: [Comparison](https://drf-api-key.koladev.xyz/docs/comparison) page against
+  djangorestframework-api-key, OAuth2, and JWT
+- Fixed: Packaging metadata — wheels were built as `py2.py3-none-any` due to a leftover
+  `universal = 1` setting; added `Requires-Python`, corrected `keyword` to `keywords`
+  (previously silently ignored), and added Django/DRF compatibility classifiers and
+  `project_urls`
 
 [v2.4.1] - 2026-01-03
 ------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ numbers are updated consistently in all the right places.
    ```
 3. Push both commits and tags: `git push && git push --tags`
 
-For more details, see the [Development and Contributing documentation](https://djangorestframework-simple-apikey.readthedocs.io/en/latest/development_and_contributing.html#version-management).
+For more details, see the [Development and Contributing documentation](https://drf-api-key.koladev.xyz/docs/development-and-contributing#version-management).
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Django REST Framework Simple API Key is a fast and secure API Key authentication
   </a>
 </div>
 
-For the full documentation, visit [https://drf-api-key.koladev.xyz](https://drf-api-key.koladev.xyz).
+For the full documentation, visit [https://drf-api-key.koladev.xyz](https://drf-api-key.koladev.xyz). Deciding between this and another package? See the [comparison with djangorestframework-api-key, OAuth2, and JWT](https://drf-api-key.koladev.xyz/docs/comparison).
 
 ## Package Renaming Notice
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Django REST Framework Simple API Key is a fast and secure API Key authentication
   </a>
 </div>
 
-For the full documentation, visit [https://djangorestframework-simple-apikey.readthedocs.io/en/latest/](https://djangorestframework-simple-apikey.readthedocs.io/en/latest/).
+For the full documentation, visit [https://drf-api-key.koladev.xyz](https://drf-api-key.koladev.xyz).
 
 ## Package Renaming Notice
 
-**Notice:** The `djangorestframework-simple-apikey` package is being renamed to `drf-simple-apikey` to improve usability and align with common naming conventions. Please update your installations:
+**Notice:** The `djangorestframework-simple-apikey` package was renamed to `drf-simple-apikey` to improve usability and align with common naming conventions. If you still have the old package installed, update it:
 
 1. Replace the old package:
    ```bash
@@ -23,7 +23,7 @@ For the full documentation, visit [https://djangorestframework-simple-apikey.rea
    pip install drf-simple-apikey
    ```
 
-For the full documentation, visit [https://djangorestframework-simple-apikey.readthedocs.io/en/latest/](https://djangorestframework-simple-apikey.readthedocs.io/en/latest/).
+See the [migration guide](https://drf-api-key.koladev.xyz/docs/migrating) for details.
 
 ## Introduction
 
@@ -113,7 +113,7 @@ python manage.py generate_fernet_key
 
 ## Rotation
 
-We implement an API key rotation strategy for this package. To learn more about it, refer to the documentation at https://djangorestframework-simple-apikey.readthedocs.io/en/latest/rotation.html.
+We implement an API key rotation strategy for this package. To learn more about it, refer to the documentation at https://drf-api-key.koladev.xyz/docs/rotation.
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,18 @@ INSTALLED_APPS = [
 ]
 ```
 
-3- Add the `FERNET_KEY` setting in your `DRF_API_KEY` configuration dictionary. You can easily generate a fernet key using the `python manage.py generate_fernet_key` command. Keep in mind that the fernet key plays a huge role in the api key authentication system.
+3 - Generate a Fernet key and put it in an environment variable — **never hardcode it in `settings.py` or commit it to version control.** Treat it exactly like your Django `SECRET_KEY`.
+
+```bash
+python manage.py generate_fernet_key
+```
 
 ```python
+# settings.py
+import os
+
 DRF_API_KEY = {
-    "FERNET_SECRET": "sVjomf7FFy351xRxDeJWFJAZaE2tG3MTuUv92TLFfOA="
+    "FERNET_SECRET": os.environ["DRF_API_KEY_FERNET_SECRET"],
 }
 ```
 
@@ -89,27 +96,20 @@ In your view then, you can add the authentication class and the permission class
 from rest_framework import viewsets
 
 from drf_simple_apikey.backends import APIKeyAuthentication
+from drf_simple_apikey.permissions import IsActiveEntity
 from rest_framework.response import Response
 
 
 class FruitViewSets(viewsets.ViewSet):
   http_method_names = ["get"]
   authentication_classes = (APIKeyAuthentication,)
+  permission_classes = (IsActiveEntity,)
 
   def list(self, request):
     return Response([{"detail": True}], 200)
 ```
 
-## Generate a Fernet Key
-We've made it easier for you by creating a custom Django command to quickly generate a fernet key, which is a **crucial component** in the authentication system. Make sure to keep the key secure and store it somewhere safely (ie: environment variable). 
-
-**Important ⛔️** : You should treat the `FERNET_KEY` security at the same level as the Django `SECRET_KEY`. 🫡
-
-To generate the fernet key use the following command:
-
-```python
-python manage.py generate_fernet_key
-```
+For the full walkthrough — creating and handing off a key, calling the API with `curl`, revoking a key, and the common 401/403 failure cases — see [Getting Started](https://drf-api-key.koladev.xyz/docs/getting-started).
 
 ## Rotation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,27 +1,36 @@
 # Security Policy
 
+For a detailed explanation of what this package protects against, what a leaked `FERNET_SECRET` exposes, and how to respond to a compromise, see the [Threat Model](https://drf-api-key.koladev.xyz/docs/threat-model) documentation.
+
 ## Supported Versions
 
-Use this section to let people know which versions of your project are currently being supported with security updates. For example:
+Security fixes are released against the latest `2.x` minor version line only. If you're on an older minor version, upgrade to the latest `2.x` release before reporting an issue, to confirm it still reproduces.
 
 | Version | Supported          |
-|---------| ------------------ |
-| 1.0.0   | :white_check_mark: |
-
-(You should modify the above table to match your project's versions and support status.)
+| ------- | ------------------ |
+| 2.4.x   | :white_check_mark: |
+| 2.3.x   | :x:                |
+| 2.2.x   | :x:                |
+| < 2.2   | :x:                |
+| 1.x     | :x:                |
+| 0.x     | :x:                |
 
 ## Reporting a Vulnerability
 
-If you believe you've found a security vulnerability in our project, we encourage you to notify us. We welcome working with you to resolve the issue promptly. 
+If you believe you've found a security vulnerability in this project, please report it privately so it can be fixed before the details are public.
 
-**Do not** create an issue on the public repository, as this can inadvertently expose the vulnerability to others.
+**Do not** open a public GitHub issue for a suspected vulnerability, as this can expose it to others before a fix is available.
 
 ### How to report
 
-Please email us directly at [koladev32@gmail.com](mailto:koladev32@gmail.com) with as many details as possible regarding the suspected vulnerability.
+Email [koladev32@gmail.com](mailto:koladev32@gmail.com) with:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce it, including the package version and relevant configuration (`DRF_API_KEY` settings) — **never include real `FERNET_SECRET` values, API keys, or other live credentials in your report.**
+- Any suggested fix or mitigation, if you have one.
 
 ### What to expect
 
-Upon receiving your email, we will review the details and get in touch with you. We aim to acknowledge your email within 48 hours, and depending on the severity of the issue, we'll strive to address it as swiftly as possible.
+We aim to acknowledge reports within 48 hours. Once confirmed, we'll work on a fix and coordinate a disclosure timeline with you, and credit you in the release notes unless you'd prefer otherwise.
 
-Thank you for helping us ensure the security and privacy of our users!
+Thank you for helping keep this project and its users secure.

--- a/drf-docs/content/docs/comparison.mdx
+++ b/drf-docs/content/docs/comparison.mdx
@@ -1,0 +1,69 @@
+---
+title: Comparison with Other Packages
+description: How drf-simple-apikey compares to djangorestframework-api-key, OAuth2, and JWT
+---
+
+If you're evaluating API-key authentication for Django REST Framework, you've probably already come across [djangorestframework-api-key](https://github.com/florimondmanca/djangorestframework-api-key) — it's the most established package in this space. This page explains where the two differ so you can pick the right one, rather than repeating marketing claims.
+
+## At a glance
+
+| | drf-simple-apikey | djangorestframework-api-key |
+| --- | --- | --- |
+| Key storage | Encrypted (Fernet) — reversible with the right secret | Hashed — irreversible, like a password |
+| Entity/user relation | Built in: every key has an `entity` FK (`AUTH_USER_MODEL` by default); `request.user` is populated on success | Not built in: the base model has no user relation; you subclass it yourself if you need one |
+| Auth mechanism | A DRF **authentication class** (`APIKeyAuthentication`) — participates in `request.user`/`request.auth` like any other authenticator | A DRF **permission class** (`HasAPIKey`) — checks the key but doesn't populate `request.user` |
+| Expiry | Built in: `expiry_date` embedded in the key payload and checked on every request | Not built in — add your own field/check if you need it |
+| Revocation | `revoked` flag, checked against the DB on every request | Built in via `.is_active`-style checks (see their docs) |
+| Key rotation | Built-in `drf_simple_apikey.rotation` app: overlapping-secret rotation for the encryption key itself | Not applicable — there's no shared secret to rotate; rotating means reissuing individual keys |
+| Scopes | Built in: `scopes` field + `HasAPIKeyScopes` permission class | Not built in — extend the model/permission class yourself |
+| IP allow/deny lists | Built in: `whitelisted_ips`/`blacklisted_ips` per key | Not built in |
+| Analytics / audit logging | Built-in optional `analytics` app (per-endpoint access counts) and structured audit log events | Not built in |
+
+## The real trade-off: encrypted vs. hashed
+
+This is the one difference worth understanding deeply before you choose, because it's a security property, not a feature checklist item.
+
+- **djangorestframework-api-key hashes keys**, the same way Django hashes passwords. The database never holds anything that can be turned back into a valid key. A stolen database dump alone is not enough to forge new keys.
+- **drf-simple-apikey encrypts keys** with Fernet. This is reversible by design: it's what lets a key carry its own expiry and entity reference without a database round trip to look up a hash, and it's what powers built-in rotation. The cost is that the single `FERNET_SECRET` protecting all of this becomes a high-value target — see the [Threat Model](/docs/threat-model) for exactly what a leaked secret exposes and how to respond.
+
+Neither approach is "more secure" in the abstract; they fail differently. Hashed storage degrades gracefully if your database leaks (attacker gets nothing usable) but has no way to embed self-describing metadata in the key. Encrypted storage lets the key carry its own expiry/identity and enables secret rotation, but a leaked encryption secret is a bigger single point of failure than a leaked hash salt.
+
+## Minimal example: drf-simple-apikey
+
+```python
+from rest_framework import viewsets
+from drf_simple_apikey.backends import APIKeyAuthentication
+from drf_simple_apikey.permissions import IsActiveEntity
+
+class FruitViewSet(viewsets.ViewSet):
+    authentication_classes = (APIKeyAuthentication,)
+    permission_classes = (IsActiveEntity,)
+
+    def list(self, request):
+        # request.user is the entity the key belongs to.
+        return Response([...])
+```
+
+## Minimal example: djangorestframework-api-key
+
+```python
+from rest_framework import viewsets
+from rest_framework_api_key.permissions import HasAPIKey
+
+class FruitViewSet(viewsets.ViewSet):
+    permission_classes = (HasAPIKey,)
+
+    def list(self, request):
+        # request.user is unaffected — HasAPIKey only validates the key.
+        return Response([...])
+```
+
+## When to choose which
+
+**Choose drf-simple-apikey** if each key should represent a specific entity (a customer, a tenant, a service account) and you want `request.user` populated automatically, you want expiry/revocation/IP restrictions/scopes without building them yourself, or you expect to need to rotate the underlying signing secret on a schedule.
+
+**Choose djangorestframework-api-key** if you want the smallest possible trust surface (hashed, non-recoverable storage) and don't need keys tied to a user model — e.g. machine-to-machine access where "the key" is the identity, not a stand-in for a user.
+
+**Choose OAuth2** (e.g. [django-oauth-toolkit](https://github.com/jazzband/django-oauth-toolkit)) if you need third-party clients, user consent, or delegated access on behalf of a user — API keys, in either package, assume you provision the credential directly to a system you trust.
+
+**Choose JWT** (e.g. [SimpleJWT](https://github.com/jazzband/djangorestframework-simplejwt)) if you need short-lived, stateless tokens for interactive user sessions rather than a long-lived credential for a server-to-server integration.

--- a/drf-docs/content/docs/getting-started.mdx
+++ b/drf-docs/content/docs/getting-started.mdx
@@ -21,79 +21,149 @@ Why should you use this package for your API Key authentication?
 
 ## Quickstart
 
-1 - Install with `pip`:
+This walks through everything needed to go from a fresh Django project to a protected endpoint that a real client can call: installing the package, generating and storing the Fernet secret safely, creating a key, calling the API with it, and revoking it.
+
+### Install
 
 ```bash
 pip install drf-simple-apikey
 ```
 
-2 - Register the app in the `INSTALLED_APPS` in the `settings.py` file:
+### Register the apps
 
 ```python
 # settings.py
 
 INSTALLED_APPS = [
-  # ...
-  "rest_framework",
-  "drf_simple_apikey",
+    # ...
+    "rest_framework",
+    "drf_simple_apikey",
 ]
 ```
 
-3- Add the `FERNET_KEY` setting in your `DRF_API_KEY` configuration dictionary. You can easily generate a fernet key using the `python manage.py generate_fernet_key` command. Keep in mind that the fernet key plays a huge role in the api key authentication system.
-
-```python
-DRF_API_KEY = {
-    "FERNET_SECRET": "sVjomf7FFy351xRxDeJWFJAZaE2tG3MTuUv92TLFfOA="
-}
-```
-
-4 - Run migrations:
-
-```bash
-python manage.py migrate
-```
-
-In your view then, you can add the authentication class and the permission class.
-
-> ⚠️ **Important Note**: By default, the Django User class (django.contrib.auth.User) is used for authentication.
-
-```python
-from rest_framework import viewsets
-
-from drf_simple_apikey.backends import APIKeyAuthentication
-from rest_framework.response import Response
-
-class FruitViewSets(viewsets.ViewSet):
-    http_method_names = ["get"]
-    authentication_classes = (APIKeyAuthentication, )
-
-    def list(self, request):
-        return Response([{"detail": True}], 200 )
-```
-
-## Generate a Fernet Key
-
-We've made it easier for you by creating a custom Django command to quickly generate a fernet key, which is a **crucial component** in the authentication system. Make sure to keep the key secure and store it somewhere safely (ie: environment variable).
-
-**Important ⛔️** : You should treat the `FERNET_KEY` security at the same level as the Django `SECRET_KEY`. 🫡
-
-To generate the fernet key use the following command:
+### Generate the Fernet secret — and keep it out of your codebase
 
 ```bash
 python manage.py generate_fernet_key
 ```
 
+This prints a key such as `sVjomf7FFy351xRxDeJWFJAZaE2tG3MTuUv92TLFfOA=`. **Treat it exactly like your Django `SECRET_KEY`**: put it in an environment variable, never commit it to version control, and never log it. See the [Threat Model](/docs/threat-model) for why this specific value matters so much.
+
+```bash
+# .env  (make sure .env is in your .gitignore)
+DRF_API_KEY_FERNET_SECRET=sVjomf7FFy351xRxDeJWFJAZaE2tG3MTuUv92TLFfOA=
+```
+
+```python
+# settings.py
+import os
+
+DRF_API_KEY = {
+    "FERNET_SECRET": os.environ["DRF_API_KEY_FERNET_SECRET"],
+}
+```
+
+Using `os.environ[...]` (not `.get(...)`) means your app fails to start with a clear `KeyError` if the secret isn't set, instead of silently running unauthenticated.
+
+### Run migrations
+
+```bash
+python manage.py migrate
+```
+
+### Protect a view
+
+Combine an authentication class with a permission class — authentication alone only identifies *who* is calling; a permission class decides whether they're allowed to proceed.
+
+```python
+from rest_framework import viewsets
+from rest_framework.response import Response
+
+from drf_simple_apikey.backends import APIKeyAuthentication
+from drf_simple_apikey.permissions import IsActiveEntity
+
+
+class FruitViewSets(viewsets.ViewSet):
+    http_method_names = ["get"]
+    authentication_classes = (APIKeyAuthentication,)
+    permission_classes = (IsActiveEntity,)
+
+    def list(self, request):
+        return Response([{"detail": True}], 200)
+```
+
+> ⚠️ By default, the Django user model (`AUTH_USER_MODEL`) is the entity an API key belongs to.
+
+### Hand off the key once
+
+The encrypted key is only ever shown at creation time — the database never stores it, so it can't be retrieved later (see [Threat Model](/docs/threat-model#encrypted-at-rest-not-hashed-at-rest) for why). Create it from a shell, a management command, or your own admin tooling:
+
+```python
+from drf_simple_apikey.models import APIKey
+
+api_key, key = APIKey.objects.create_api_key(entity=user)
+
+print(key)
+# gAAAAABn...  — send this to the integration now, over a channel you
+# control (a secrets manager, a one-time-view link, etc). It will
+# never be shown again; if it's lost, revoke it and issue a new one.
+```
+
+If you create the key through the Django admin instead, the same one-time key is shown as a warning message on the change page right after saving.
+
+### Call the API
+
+Send the key in the `Authorization` header, prefixed with the configured keyword (`Api-Key` by default — see [`AUTHENTICATION_KEYWORD_HEADER`](/docs/settings)):
+
+```bash
+curl https://your-api.example.com/fruits/ \
+  -H "Authorization: Api-Key gAAAAABn..."
+```
+
+### `request.user` and `request.auth`
+
+Once authentication succeeds, both are populated for the rest of the request:
+
+- **`request.user`** is the entity the key belongs to — a Django user by default.
+- **`request.auth`** is the `APIKey` model instance used to authenticate (not the raw key string), so a view or permission class can read `request.auth.scopes`, `request.auth.expiry_date`, `request.auth.name`, etc.
+
+### Revoke a key
+
+```python
+APIKey.objects.revoke_api_key(api_key.pk)
+```
+
+A revoked key immediately fails authentication with `"This API Key has been revoked."`, regardless of its expiry date.
+
+### Rotate the Fernet secret
+
+Revoking is per-key. To change the `FERNET_SECRET` itself — on a schedule, as a precaution, not as incident response for a suspected leak — see [Rotation](/docs/rotation). If you suspect the secret itself has already leaked, follow the [incident response steps](/docs/threat-model#incident-response-the-fernet-secret-is-confirmed-or-suspected-leaked) instead: rotation intentionally keeps the old secret trusted during its transition window, which is the wrong behavior when that old secret is the one that's compromised.
+
+## Common failure responses
+
+Every rejection from this package — a failed authentication *and* a failed permission check — comes back as **`403 Forbidden`**, not `401 Unauthorized`. DRF only returns 401 when an authenticator supplies a `WWW-Authenticate` header, and this backend deliberately doesn't (`authenticate_header()` returns `None`), so don't special-case 401 in client code that talks to this API.
+
+| `detail` message | Cause |
+| --- | --- |
+| `No API key provided.` | No `Authorization` header was sent at all. |
+| `Incorrect API KEY format.` | The header is present but doesn't match `<AUTHENTICATION_KEYWORD_HEADER> <key>` (e.g. missing the `Api-Key ` prefix). |
+| `Invalid API Key.` | The value isn't a valid Fernet token for the configured `FERNET_SECRET` — wrong secret, corrupted value, or a key issued under a different secret. |
+| `API Key has already expired.` | The key's `expiry_date` is in the past. |
+| `This API Key has been revoked.` | The key's `revoked` flag is `True`. |
+| `No entity matching this api key.` | The underlying `APIKey` row was deleted after the key was issued. |
+| `Access denied from blacklisted IP.` / `Access restricted to specific IP addresses.` | The caller's IP is blocked by `blacklisted_ips`/`whitelisted_ips`. |
+| `API key authentication requires HTTPS...` | `ENFORCE_HTTPS` is on and the request arrived over plain HTTP. |
+| A permission class's own `message` (e.g. `IsActiveEntity`'s `"Entity is not active."`) | Authentication succeeded, but a permission class rejected the request — check `permission_classes` on the view. |
+
 ## Security Considerations
 
-Before deploying to production, here are a few security tips to keep in mind:
+Before deploying to production:
 
-- **Treat your Fernet key like your Django SECRET_KEY**: Store it in environment variables, never commit it to version control, and rotate it periodically.
+- **Treat your Fernet key like your Django `SECRET_KEY`**: environment variables only, never in version control, never in logs.
+- **Always use HTTPS in production**: the package can enforce this automatically. See [Security](/docs/security) for details.
+- **Review your audit logs**: the package logs authentication and revocation events — make sure something is actually watching them.
 
-- **Always use HTTPS in production**: The package can enforce HTTPS connections to prevent API keys from being transmitted over unencrypted HTTP. See [Security](/docs/security) for details.
-
-- **Review your audit logs**: The package logs important security events. Make sure you're monitoring these logs to catch any suspicious activity.
-
-For more detailed security information, check out the [Security](/docs/security) documentation.
+For the full picture of what this design protects against, read the [Threat Model](/docs/threat-model). For feature-by-feature details, see [Security](/docs/security).
 
 ## Changelog
 
@@ -102,4 +172,3 @@ See [CHANGELOG.md](https://github.com/koladev32/drf-simple-apikey/blob/main/CHAN
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/koladev32/drf-simple-apikey/blob/main/CONTRIBUTING.md).
-

--- a/drf-docs/content/docs/index.mdx
+++ b/drf-docs/content/docs/index.mdx
@@ -7,6 +7,8 @@ An API Key authentication plugin for the [Django REST Framework](http://www.djan
 
 Django REST Simple Api Key is a package built upon Django, Django REST Framework, and the fernet cryptography module to generate, encrypt, and decrypt API keys.
 
+New to API-key authentication in Django, or deciding between packages? See [Getting Started](/docs/getting-started) for a full walkthrough, or [Comparison with Other Packages](/docs/comparison) if you're weighing this against djangorestframework-api-key, OAuth2, or JWT.
+
 ## Acknowledgments
 
 This project borrows code from the [Django REST Framework](https://github.com/encode/django-rest-framework/) as well as concepts from the implementation of another API Key library for the Django REST Framework, [djangorestframework-api-key](https://github.com/florimondmanca/djangorestframework-api-key).

--- a/drf-docs/content/docs/meta.json
+++ b/drf-docs/content/docs/meta.json
@@ -2,6 +2,7 @@
   "pages": [
     "index",
     "getting-started",
+    "comparison",
     "settings",
     "authentication",
     "permissions",

--- a/drf-docs/content/docs/meta.json
+++ b/drf-docs/content/docs/meta.json
@@ -7,6 +7,7 @@
     "permissions",
     "customizing-api-key-model",
     "security",
+    "threat-model",
     "rotation",
     "analytics",
     "migrating",

--- a/drf-docs/content/docs/migrating.mdx
+++ b/drf-docs/content/docs/migrating.mdx
@@ -57,7 +57,7 @@ Ensure that you update these settings throughout your project configuration file
 
 ## Support and Feedback
 
-For more information, detailed support, or to provide feedback about the migration process, please visit our documentation site at https://djangorestframework-simple-apikey.readthedocs.io/en/latest/ or open an issue on GitHub.
+For more information, detailed support, or to provide feedback about the migration process, please browse the rest of this documentation site or [open an issue on GitHub](https://github.com/koladev32/drf-simple-apikey/issues).
 
 We appreciate your cooperation and understanding as we continue to improve our software offerings.
 

--- a/drf-docs/content/docs/security.mdx
+++ b/drf-docs/content/docs/security.mdx
@@ -5,6 +5,8 @@ description: Security features and best practices for API key authentication
 
 Keeping your API keys secure is crucial, and we've built several security features into the package to help protect your API. This page explains how these features work and why they matter.
 
+For a deeper look at what a leaked `FERNET_SECRET` actually exposes and how to respond to it, see the [Threat Model](/docs/threat-model).
+
 ## Why Security Matters
 
 API keys are like passwords: if someone gets hold of them, they can access your API as if they were the legitimate user. That's why we've implemented multiple layers of security to keep your API keys safe from common attacks.

--- a/drf-docs/content/docs/threat-model.mdx
+++ b/drf-docs/content/docs/threat-model.mdx
@@ -1,0 +1,76 @@
+---
+title: Threat Model
+description: What a Fernet secret protects, what happens if it leaks, and how to respond
+---
+
+This page explains, concretely, what this package's cryptographic design does and does not protect against. Read this before you decide the Fernet secret can live somewhere less carefully guarded than your Django `SECRET_KEY`.
+
+## Encrypted-at-rest, not hashed-at-rest
+
+Most API key libraries store a **hash** of the key (like a password hash): the raw key exists only once, at creation time, and the database never holds anything an attacker could turn back into a valid key. A stolen database dump is useless on its own.
+
+This package works differently. An API key is a [Fernet](https://cryptography.io/en/latest/fernet/) token — a symmetric, **reversible** encryption of a small JSON payload (`{"_pk": <api key row id>, "_exp": <expiry timestamp>}`). Nothing about the key itself is stored in the database; instead, the database row (`revoked`, `expiry_date`, `whitelisted_ips`, `scopes`, ...) is looked up by the `_pk` embedded in the token once it's decrypted.
+
+This trade-off is deliberate: it means issuing, inspecting, and revoking keys never requires storing a hash comparable to the original secret, and it lets the key carry its own expiry. But it also means **the single `FERNET_SECRET` is the only thing standing between an attacker and every key you've ever issued** — current, past, and future, until you change it.
+
+## What a leaked Fernet secret lets an attacker do
+
+If `FERNET_SECRET` leaks, an attacker does not need to steal any individual API key, intercept traffic, or touch your database. With the secret alone they can:
+
+- **Forge a valid key for any entity ID they choose.** `assign_api_key` (`drf_simple_apikey/models.py`) just encrypts `{"_pk": obj.pk, "_exp": ...}`. Anyone holding `FERNET_SECRET` can encrypt that same payload for any `_pk` — including ids they merely guess (e.g. `1`, `2`, `3`) — and get back a token that passes signature verification and decryption.
+- **Decrypt any token they capture**, revealing which entity and expiry it maps to.
+- **Bypass expiry** by setting `_exp` arbitrarily far in the future in a forged token.
+
+What a leaked secret does **not** immediately do:
+
+- It does not bypass the `revoked` flag, IP allow/deny lists, or `scopes` — those are enforced from the database row after decryption succeeds, not from the token itself. A forged token for a real, non-revoked entity still works; a forged token pointing at an id that doesn't exist, or at a row you've since revoked, still fails.
+
+This is why revocation matters even when the secret hasn't leaked, and why it becomes essential — not optional — once you suspect it has.
+
+## Protecting the secret
+
+- Store `FERNET_SECRET` (and `ROTATION_FERNET_SECRET`, if you use [rotation](/docs/rotation)) in an environment variable or a secrets manager — never in source control, never logged.
+- Treat it exactly like Django's `SECRET_KEY`: same access controls, same handling in CI/CD, same exclusion from error reporting/logging integrations.
+- Generate it with `python manage.py generate_fernet_key` rather than hand-rolling one; the package validates key format and warns about low-entropy or placeholder-looking keys (see [Security](/docs/security#fernet-key-security)).
+
+## Rotation is for planned key changes, not incident response
+
+The built-in [rotation](/docs/rotation) mechanism (`drf_simple_apikey.rotation`) is designed for periodic, **planned** key changes: during the transition window, both the old and new Fernet keys decrypt successfully (via `MultiFernet`), so already-issued keys keep working while new keys are encrypted with the new secret.
+
+That overlap is exactly why rotation is the wrong tool for responding to a confirmed leak: if the *old* secret is the one that was compromised, it stays trusted for the entire `ROTATION_PERIOD` transition window, and anything an attacker forged with it keeps validating until the window closes.
+
+## Incident response: the Fernet secret is confirmed or suspected leaked
+
+Do these in order:
+
+1. **Revoke every existing key immediately** — `APIKey.objects.revoke_api_key(pk)` for each row, or a bulk `APIKey.objects.filter(revoked=False).update(revoked=True)` if you need it fast. This is the only step that stops a forged token from working *right now*, since revocation is checked from the database regardless of which secret decrypted the token.
+2. **Generate a brand-new `FERNET_SECRET`** — do not feed the compromised value into `ROTATION_FERNET_SECRET`. Rotation assumes the old key is still trustworthy for the overlap period; a compromised key is, by definition, not.
+3. **Deploy the new secret and restart** so every process picks it up.
+4. **Re-issue keys** to your legitimate integrations and hand off the new secrets through a channel you control (see [Getting Started](/docs/getting-started#hand-off-the-key-once)).
+5. **Review audit logs** (`ENABLE_AUDIT_LOGGING`) for authentication activity in the window before you rotated, looking for entity IDs or IP addresses you don't recognize.
+
+## Responding to a single leaked API key
+
+If only one integration's key leaked (not the Fernet secret itself), you don't need to touch the secret at all — revoke that one row:
+
+```python
+from drf_simple_apikey.models import APIKey
+
+APIKey.objects.revoke_api_key(pk)
+```
+
+Issue a replacement key to that integration and confirm the old one now fails with `"This API Key has been revoked."`.
+
+## API keys are not a substitute for user authentication
+
+API keys, as implemented here, are a **long-lived, static bearer credential** tied to a single entity — well suited to server-to-server and machine-to-machine integrations where the caller is a system you provision directly. They are not a substitute for:
+
+- **User login** — no password, MFA, or session semantics; anyone holding the key acts as the entity indefinitely (until expiry/revocation).
+- **OAuth2** — no consent flow, no third-party delegation, no per-client secrets.
+- **Short-lived delegated access** (e.g. signed URLs, JWTs with minute-scale expiry) — the default `API_KEY_LIFETIME` is a year, and even a short expiry doesn't give you the ability to constrain *what* the token can do beyond [scopes](/docs/permissions#scopes) and IP restrictions.
+
+If you need interactive user login, use Django's own authentication or a package built for it. Use this package for the machine-identity half of your system.
+
+## Minimum supported version
+
+Only run a version listed as supported in [SECURITY.md](https://github.com/koladev32/drf-simple-apikey/blob/main/SECURITY.md). Security fixes are released against the latest minor version line; if you're several minor versions behind, upgrade before filing a report to confirm the issue still reproduces.

--- a/drf_simple_apikey/__init__.py
+++ b/drf_simple_apikey/__init__.py
@@ -4,17 +4,6 @@ Django REST framework Simple API Key Configurations
 
 import django
 
-import warnings
-
-warnings.warn(
-    "This package, 'djangorestframework-simple-apikey', has been renamed to 'drf-simple-apikey' and will no longer be updated."
-    "Please switch to the new package to continue receiving updates and support. "
-    "For more information and migration instructions, please visit: https://djangorestframework-simple-apikey.readthedocs.io/en/latest/migrating.html",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-
 __title__ = "Django REST framework Simple API Key"
 __author__ = ["Kolawole Mangabo", "Ruben Atinho"]
 

--- a/drf_simple_apikey/settings.py
+++ b/drf_simple_apikey/settings.py
@@ -34,7 +34,7 @@ class PackageSettings(_APISettings):
         return self._user_settings
 
     def __check_user_settings(self, user_settings):
-        SETTINGS_DOC = "https://djangorestframework-simple-apikey.readthedocs.io/en/latest/settings.html"
+        SETTINGS_DOC = "https://drf-api-key.koladev.xyz/docs/settings"
 
         for setting in REMOVED_SETTINGS:
             if setting in user_settings:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,4 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "drf-simple-apikey"
 version = "2.4.1"
-dynamic = ["description", "readme", "optional-dependencies", "dependencies", "classifiers", "authors", "license"]
+dynamic = ["description", "readme", "optional-dependencies", "dependencies", "classifiers", "authors", "license", "keywords", "requires-python", "urls"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,9 +22,6 @@ replace =
 	[v{new_version}] - {utcnow:%%Y-%%m-%%d}
 	------------------
 
-[bdist_wheel]
-universal = 1
-
 [metadata]
 name = drf-simple-apikey
 version = "{current_version}"
@@ -32,28 +29,42 @@ url = https://github.com/koladev32/drf-simple-apikey
 license = MIT
 author = Kolawole Mangabo
 author_email = onaelmangabo@gmail.com
-description = API Key authentication and permissions for Django REST.
+description = Secure, fast API key authentication and permissions for Django REST Framework, with built-in encryption, expiry, revocation, scopes, IP allow/deny lists, and key rotation.
 long_description = file: README.md
 long_description_content_type = text/markdown
-keyword = django django-rest api-key apikey
-classifiers = 
+keywords = django, django-rest-framework, drf, api-key, apikey, authentication, permissions, fernet, rest-api
+project_urls =
+	Documentation = https://drf-api-key.koladev.xyz
+	Source = https://github.com/koladev32/drf-simple-apikey
+	Changelog = https://github.com/koladev32/drf-simple-apikey/blob/main/CHANGELOG.md
+	Issue Tracker = https://github.com/koladev32/drf-simple-apikey/issues
+classifiers =
 	Development Status :: 5 - Production/Stable
+	Framework :: Django
+	Framework :: Django :: 4.2
+	Framework :: Django :: 5.0
+	Framework :: Django :: 5.1
+	Framework :: Django :: 5.2
 	Intended Audience :: Developers
 	License :: OSI Approved :: MIT License
 	Operating System :: OS Independent
 	Programming Language :: Python
+	Programming Language :: Python :: 3
+	Programming Language :: Python :: 3 :: Only
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
 	Programming Language :: Python :: 3.12
 	Programming Language :: Python :: 3.13
-	Programming Language :: Python :: Implementation :: PyPy
+	Topic :: Internet :: WWW/HTTP
+	Topic :: Security
 	Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
 zip_safe = False
 include_package_data = True
 packages = find:
-install_requires = 
+python_requires = >=3.10
+install_requires =
 	django >= 4.2.17,<6.0
 	djangorestframework >= 3.15.2
 	cryptography >= 43.0.0


### PR DESCRIPTION
## Summary

Batch of documentation and packaging fixes, one commit per issue.

- **Closes #120** — Removed an `__init__.py` `DeprecationWarning` that told users of the *current* `drf-simple-apikey` package to switch away from itself under its old name. Replaced stale `djangorestframework-simple-apikey.readthedocs.io` links (README, CONTRIBUTING, `settings.py`, `migrating.mdx`) with the canonical `https://drf-api-key.koladev.xyz`.
- **Closes #121** — New [Threat Model](https://drf-api-key.koladev.xyz/docs/threat-model) page: encrypted-vs-hashed storage trade-off, exactly what a leaked `FERNET_SECRET` lets an attacker do (and doesn't), why rotation isn't the right incident-response tool, concrete revoke/rotate incident-response steps, and why API keys aren't a login/OAuth2 substitute. Linked from `security.mdx`.
- **Closes #115** — `SECURITY.md` had the generic GitHub template placeholder content; replaced with a real supported-versions table and reporting instructions, linking to the new threat model doc.
- **Closes #119** — Quickstart rewritten end-to-end: Fernet secret from an env var (not a literal example value), key creation and one-time secret hand-off, an exact `curl` request, `authentication_classes` + `permission_classes` together, what `request.user`/`request.auth` are, revocation, rotation vs. incident response, and a full table of failure `detail` messages. Also documents (and explains) that every rejection is `403`, not `401`, since `authenticate_header()` returns `None`.
- **Closes #117** — New [Comparison](https://drf-api-key.koladev.xyz/docs/comparison) page against djangorestframework-api-key (verified its actual storage model/permission classes against its docs before writing this — encrypted/reversible vs. hashed/irreversible is the real trade-off, not a feature checklist), plus guidance on when OAuth2 or JWT fit better. Linked from the README's first screen and the docs landing page.
- **Closes #118** — Packaging metadata fixes, verified with a real build:
  - `[bdist_wheel] universal = 1` was tagging every release `py2.py3-none-any` for a Python-3-only package. Removed; confirmed wheel now builds as `py3-none-any`.
  - Added `python_requires = >=3.10` (was previously unset — pip/PyPI enforced nothing).
  - `keyword = ...` wasn't a real setuptools/PyPI key; the intended keywords were silently dropped. Fixed to `keywords = ...`.
  - Added `project_urls`, `Framework :: Django :: {4.2,5.0,5.1,5.2}` classifiers matching `install_requires`, and dropped the untested `Implementation :: PyPy` classifier (CI only tests CPython 3.10–3.13).
  - `pyproject.toml`'s `dynamic` list didn't include `keywords`/`requires-python`/`urls`, which is why setting them in `setup.cfg` had no effect (and initially broke the build until fixed — see commit).

## Also filed (not fixed here, out of scope for a docs/packaging PR)

While verifying the quickstart's failure-case table empirically, found that `cryptography.fernet.InvalidToken` isn't caught by the narrow `except (ValueError, TypeError)` in `_authenticate_credentials`, so every malformed API key gets logged as an ERROR-level "unexpected error" with a full traceback instead of a routine auth failure. Filed as #122.

## Test plan
- [x] `pytest` (41 passed) after the `__init__.py` change
- [x] `python -m build --sdist --wheel` + `twine check` on both artifacts — PASSED, wheel confirmed `py3-none-any`
- [x] Reinstalled editable (`pip install -e .[test]`) after the packaging change and reran the full suite (41 passed)
- [x] Cross-checked every new internal doc anchor link (`/docs/threat-model#...`, `/docs/getting-started#...`) against the actual heading slugs