### PR TITLE
Fix rotation_status cache never invalidated on start/stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 [Unreleased]
 ------------
 
+- Fixed: `get_rotation_status()` cached a "no active rotation" result forever
+  (`timeout=None`), so starting a rotation afterwards had no effect until the
+  cache was cleared manually. Starting/stopping a rotation via the management
+  command or the admin now invalidates the cache immediately, and the negative
+  result is now bounded to 60s as a safety net
 - Added: Per-key scopes. `APIKey` now has a `scopes` field, and a new `HasAPIKeyScopes`
   permission class enforces a view's `required_scopes` against the authenticated key.
   Keys without scopes remain unrestricted (backward compatible).

--- a/drf_simple_apikey/management/commands/rotation.py
+++ b/drf_simple_apikey/management/commands/rotation.py
@@ -4,6 +4,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 
 from drf_simple_apikey.rotation.models import Rotation
+from drf_simple_apikey.rotation.utils import invalidate_rotation_status_cache
 from drf_simple_apikey.settings import package_settings
 
 
@@ -27,6 +28,7 @@ class Command(BaseCommand):
                 rotation.is_rotation_enabled = False
                 rotation.ended = timezone.now()
                 rotation.save()
+                invalidate_rotation_status_cache()
                 self.stdout.write(self.style.SUCCESS("Successfully stopped rotation"))
             except Rotation.DoesNotExist:
                 raise CommandError("No active rotation found to stop")
@@ -36,6 +38,7 @@ class Command(BaseCommand):
             obj.is_rotation_enabled = True
             obj.ended = timezone.now() + package_settings.ROTATION_PERIOD
             obj.save()
+            invalidate_rotation_status_cache()
             self.stdout.write(
                 self.style.SUCCESS(
                     f"Successfully started rotation ending at {obj.ended}"

--- a/drf_simple_apikey/rotation/admin.py
+++ b/drf_simple_apikey/rotation/admin.py
@@ -7,6 +7,7 @@ from django.http.request import HttpRequest
 from django.utils import timezone
 
 from .models import Rotation
+from .utils import invalidate_rotation_status_cache
 from ..settings import package_settings
 
 
@@ -53,6 +54,8 @@ class RotationAdmin(admin.ModelAdmin):
             messages.add_message(request, messages.WARNING, message)
         else:
             obj.save()
+
+        invalidate_rotation_status_cache()
 
 
 admin.site.register(Rotation, RotationAdmin)

--- a/drf_simple_apikey/rotation/utils.py
+++ b/drf_simple_apikey/rotation/utils.py
@@ -6,9 +6,28 @@ from django.utils import timezone
 
 from drf_simple_apikey.settings import package_settings
 
+ROTATION_STATUS_CACHE_KEY = "rotation_status"
+
+# How long a "no active rotation" result stays cached. This is deliberately
+# short and bounded (unlike the "rotation is active" case, which is cached
+# for the full ROTATION_PERIOD): it's a self-healing safety net in case some
+# code path starts or stops a Rotation without calling
+# invalidate_rotation_status_cache() below, so the package doesn't get stuck
+# believing rotation is disabled indefinitely.
+_NEGATIVE_CACHE_TIMEOUT = 60
+
+
+def invalidate_rotation_status_cache() -> None:
+    """
+    Call this whenever a `Rotation` row is created, started, or stopped, so
+    `get_rotation_status()` recomputes its value on the next call instead of
+    returning a stale cached result.
+    """
+    cache.delete(ROTATION_STATUS_CACHE_KEY)
+
 
 def get_rotation_status() -> bool:
-    rotation_status = cache.get("rotation_status")
+    rotation_status = cache.get(ROTATION_STATUS_CACHE_KEY)
 
     if (
         rotation_status is None
@@ -35,13 +54,13 @@ def get_rotation_status() -> bool:
 
         # Cache the rotation status
         cache.set(
-            "rotation_status",
+            ROTATION_STATUS_CACHE_KEY,
             rotation_status,
             (
                 package_settings.ROTATION_PERIOD.total_seconds()
                 if rotation_status
-                else None
+                else _NEGATIVE_CACHE_TIMEOUT
             ),
-        )  # Cache for the rotation period if true
+        )  # Cache for the rotation period if true, briefly otherwise
 
     return rotation_status

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -1,0 +1,73 @@
+import os
+
+import pytest
+from django.core.cache import cache
+from django.core.management import call_command
+
+from drf_simple_apikey.rotation.utils import (
+    ROTATION_STATUS_CACHE_KEY,
+    get_rotation_status,
+)
+
+pytestmark = pytest.mark.django_db
+
+ROTATION_ENABLED = bool(os.environ.get("TEST_WITH_ROTATION"))
+
+
+@pytest.mark.skipif(
+    not ROTATION_ENABLED, reason="Requires the rotation app (TEST_WITH_ROTATION=1)"
+)
+class TestRotationStatusCache:
+    def setup_method(self):
+        from drf_simple_apikey.rotation.models import Rotation
+
+        cache.delete(ROTATION_STATUS_CACHE_KEY)
+        Rotation.objects.all().delete()
+
+    def test_starting_rotation_via_command_invalidates_stale_cached_status(self):
+        # Cache the "no rotation" result, exactly as authenticating a
+        # request naturally would before any rotation is started.
+        assert get_rotation_status() is False
+
+        call_command("rotation")
+
+        # Before the fix, this kept returning the stale cached False
+        # forever, since the negative result was cached with timeout=None
+        # and nothing invalidated it when the rotation started.
+        assert get_rotation_status() is True
+
+    def test_stopping_rotation_via_command_invalidates_stale_cached_status(self):
+        call_command("rotation")
+        assert get_rotation_status() is True
+
+        call_command("rotation", "--stop")
+
+        assert get_rotation_status() is False
+
+
+@pytest.mark.skipif(
+    not ROTATION_ENABLED, reason="Requires the rotation app (TEST_WITH_ROTATION=1)"
+)
+class TestRotationAdminCacheInvalidation:
+    def setup_method(self):
+        from drf_simple_apikey.rotation.models import Rotation
+
+        cache.delete(ROTATION_STATUS_CACHE_KEY)
+        Rotation.objects.all().delete()
+
+    def test_creating_a_rotation_via_admin_invalidates_stale_cached_status(self, rf):
+        from django.contrib.admin import site
+
+        from drf_simple_apikey.rotation.admin import RotationAdmin
+        from drf_simple_apikey.rotation.models import Rotation
+
+        from .test_admin import build_admin_request
+
+        assert get_rotation_status() is False
+
+        request = build_admin_request(rf)
+        admin = RotationAdmin(Rotation, site)
+        rotation = Rotation(is_rotation_enabled=False)
+        admin.save_model(request, obj=rotation)
+
+        assert get_rotation_status() is True


### PR DESCRIPTION
## Summary

`get_rotation_status()` (`drf_simple_apikey/rotation/utils.py`) caches a "no active rotation" result with `timeout=None` — cached forever. Once that's cached, starting a rotation has no way to correct it: `get_rotation_status()` short-circuits on `cache.get(...) is not None` and returns the stale `False` on every call, so rotation never actually takes effect until the cache row is dropped manually. This matches the reported repro exactly — a `rotation_status` cache row with `expires = 9999-12-31`.

## Fix

- Added `invalidate_rotation_status_cache()` and called it from every place that mutates a `Rotation` row:
  - the `rotation` management command's start and `--stop` paths
  - `RotationAdmin.save_model` (covers both creating a new rotation and toggling `is_rotation_enabled` on an existing one from the change form)
- Bounded the "no active rotation" cache entry to 60s instead of `None`, as a self-healing safety net for any other code path that creates/edits a `Rotation` row without going through the two call sites above.

Closes #99.

## Test plan
- [x] Added `tests/test_rotation.py`, exercising the exact reported repro: start via `manage.py rotation`, confirm `get_rotation_status()` flips to `True` immediately (no manual cache clear); stop via `--stop` and confirm it flips back; same for the admin `save_model` path.
- [x] Verified these tests actually catch the regression: reverted the fix locally and confirmed they fail (import error / stale `False`) before re-applying it.
- [x] `pytest` (41 passed, 3 skipped — the new tests skip when the rotation app isn't installed) and `TEST_WITH_ROTATION=1 pytest` (44 passed) both green.
- [x] `black --check` on all changed/added files.