### PR TITLE
APIKeyAuthentication.authenticate() returns None when no key is present, instead of raising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Changelog
 [Unreleased]
 ------------
 
+- **Changed (potentially breaking)**: `APIKeyAuthentication` now returns `None`
+  instead of raising `NotAuthenticated`/`AuthenticationFailed` when the request
+  has no `Authorization` header or uses a different scheme's keyword, matching
+  DRF's authenticator contract. This lets it be combined with other
+  authentication classes (previously it always hard-rejected the request
+  first). **If `APIKeyAuthentication` is your only authentication class and
+  you relied on a missing key being rejected automatically, add a permission
+  class (e.g. `IsActiveEntity`) to your view** — authentication alone no
+  longer enforces that a key was provided; see [Getting Started](https://drf-api-key.koladev.xyz/docs/getting-started#protect-a-view).
 - Fixed: `get_rotation_status()` cached a "no active rotation" result forever
   (`timeout=None`), so starting a rotation afterwards had no effect until the
   cache was cleared manually. Starting/stopping a rotation via the management

--- a/drf-docs/content/docs/authentication.mdx
+++ b/drf-docs/content/docs/authentication.mdx
@@ -29,6 +29,22 @@ DRF_API_KEY = {
 }
 ```
 
+## Combining with other authenticators
+
+`APIKeyAuthentication` follows Django REST Framework's authenticator contract: if the request has no `Authorization` header, or the header uses a different scheme (e.g. `Bearer ...` or `Basic ...`), it returns `None` instead of raising — signaling "not my request to handle" so DRF moves on to the next authenticator in `authentication_classes`. It only raises `AuthenticationFailed` once it's confirmed the request *is* attempting `Api-Key` auth but the value itself is malformed, expired, revoked, or otherwise invalid.
+
+This makes it safe to combine with other authentication classes on the same view:
+
+```python
+from rest_framework.authentication import SessionAuthentication
+
+class YourViewSet(viewsets.ViewSet):
+    authentication_classes = (APIKeyAuthentication, SessionAuthentication)
+    ...
+```
+
+A request with a valid session but no `Api-Key` header authenticates via `SessionAuthentication` instead of being rejected outright. Conversely, if none of your authenticators match, `request.user` is `AnonymousUser` — add a permission class (see [Permissions](/docs/permissions)) if anonymous access should be rejected rather than silently allowed.
+
 ## Security Features
 
 The authentication backend includes several security features to protect your API:

--- a/drf-docs/content/docs/getting-started.mdx
+++ b/drf-docs/content/docs/getting-started.mdx
@@ -73,7 +73,7 @@ python manage.py migrate
 
 ### Protect a view
 
-Combine an authentication class with a permission class — authentication alone only identifies *who* is calling; a permission class decides whether they're allowed to proceed.
+Combine an authentication class with a permission class — authentication alone only identifies *who* is calling; a permission class decides whether they're allowed to proceed. This matters concretely here: a request with no `Authorization` header at all, or one using a different scheme, isn't treated as an error by `APIKeyAuthentication` — it's simply not this authenticator's request to handle, so DRF falls through to `request.user` being `AnonymousUser`. Without a permission class, that request would proceed *unauthenticated*. `IsActiveEntity` below closes that gap: `AnonymousUser.is_active` is `False`, so an anonymous request is still rejected.
 
 ```python
 from rest_framework import viewsets
@@ -141,12 +141,13 @@ Revoking is per-key. To change the `FERNET_SECRET` itself — on a schedule, as 
 
 ## Common failure responses
 
-Every rejection from this package — a failed authentication *and* a failed permission check — comes back as **`403 Forbidden`**, not `401 Unauthorized`. DRF only returns 401 when an authenticator supplies a `WWW-Authenticate` header, and this backend deliberately doesn't (`authenticate_header()` returns `None`), so don't special-case 401 in client code that talks to this API.
+Every rejection from this package — a failed authentication *and* a failed permission check — comes back as **`403 Forbidden`**, not `401 Unauthorized`, as long as `APIKeyAuthentication` is the first authentication class on the view. DRF only returns 401 when the *first* listed authenticator supplies a `WWW-Authenticate` header, and this backend deliberately doesn't (`authenticate_header()` returns `None`), so don't special-case 401 in client code that talks to this API.
+
+A missing `Authorization` header, or one using a different scheme (e.g. `Bearer ...`), doesn't produce a `detail` message from this backend at all — `APIKeyAuthentication` simply returns `None` and defers to whatever's next: another authentication class, if you've configured one (see [Authentication](/docs/authentication#combining-with-other-authenticators)), or otherwise an anonymous `request.user` that your permission classes are responsible for rejecting.
 
 | `detail` message | Cause |
 | --- | --- |
-| `No API key provided.` | No `Authorization` header was sent at all. |
-| `Incorrect API KEY format.` | The header is present but doesn't match `<AUTHENTICATION_KEYWORD_HEADER> <key>` (e.g. missing the `Api-Key ` prefix). |
+| `Incorrect API KEY format.` | The header uses the configured keyword (`Api-Key` by default) but doesn't match `<AUTHENTICATION_KEYWORD_HEADER> <key>` — e.g. the key itself is missing, or contains a stray space. |
 | `Invalid API Key.` | The value isn't a valid Fernet token for the configured `FERNET_SECRET` — wrong secret, corrupted value, or a key issued under a different secret. |
 | `API Key has already expired.` | The key's `expiry_date` is in the past. |
 | `This API Key has been revoked.` | The key's `revoked` flag is `True`. |

--- a/drf_simple_apikey/parser.py
+++ b/drf_simple_apikey/parser.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 
 from django.http import HttpRequest
-from rest_framework.exceptions import NotAuthenticated, AuthenticationFailed
+from rest_framework.exceptions import AuthenticationFailed
 
 from drf_simple_apikey.settings import package_settings
 
@@ -15,7 +15,6 @@ class APIKeyParser:
     """
 
     keyword = package_settings.AUTHENTICATION_KEYWORD_HEADER
-    message = "No API key provided."
 
     def get(self, request: HttpRequest) -> str | None:
         return self.get_from_authorization(request)
@@ -24,14 +23,26 @@ class APIKeyParser:
         authorization = request.META.get("HTTP_AUTHORIZATION")
 
         if not authorization:
-            raise NotAuthenticated(self.message)
+            # No Authorization header at all: this isn't an attempt to use
+            # this scheme, so let DRF try the next authentication class
+            # instead of failing the request outright.
+            return None
 
-        try:
-            _, key = authorization.split(f"{self.keyword} ")
-        except ValueError:
+        parts = authorization.split()
+
+        if not parts or parts[0] != self.keyword:
+            # Present, but not our keyword (e.g. "Bearer ..."): again, not
+            # an attempt to use this scheme.
+            return None
+
+        if len(parts) != 2:
+            # Our keyword is present, so this *is* an attempt to use this
+            # scheme, just a malformed one (missing key, or extra spaces
+            # inside it) — that's worth a real error instead of a silent
+            # fall-through.
             raise AuthenticationFailed("Incorrect API KEY format.")
 
-        return key
+        return parts[1]
 
     def get_from_header(self, request: HttpRequest, name: str) -> str | None:
         return request.META.get(name) or None

--- a/tests/test_api_authentication.py
+++ b/tests/test_api_authentication.py
@@ -1,10 +1,21 @@
+import base64
+
 import pytest
 
 from django.contrib.auth.models import User
 from rest_framework import exceptions
+from rest_framework.authentication import BasicAuthentication
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 
 from rest_framework.test import APIRequestFactory
 
+from drf_simple_apikey.backends import APIKeyAuthentication
 from drf_simple_apikey.settings import package_settings
 
 from .fixtures.user import user
@@ -72,15 +83,34 @@ class TestApiKeyAuthentication:
 
         assert isinstance(entity, User)
 
-    def test_authenticate_invalid_request(self, invalid_request):
-        entity = None
-        with pytest.raises(
-            exceptions.NotAuthenticated,
-            match=r"No API key provided.",
-        ):
-            entity, _ = api_key_authentication().authenticate(invalid_request)
+    def test_authenticate_request_without_authorization_header_returns_none(
+        self, invalid_request
+    ):
+        # No Authorization header at all means this isn't an attempt to use
+        # this scheme: DRF expects None here so it can try the next
+        # authentication class instead of the request failing outright.
+        assert api_key_authentication().authenticate(invalid_request) is None
 
-        assert entity is None
+    def test_authenticate_request_with_different_auth_scheme_returns_none(self, user):
+        factory = APIRequestFactory()
+        request = factory.get(
+            "/test-request/", HTTP_AUTHORIZATION="Bearer some-other-token"
+        )
+
+        assert api_key_authentication().authenticate(request) is None
+
+    def test_authenticate_request_with_matching_keyword_but_no_key_raises(self, user):
+        factory = APIRequestFactory()
+        request = factory.get(
+            "/test-request/",
+            HTTP_AUTHORIZATION=package_settings.AUTHENTICATION_KEYWORD_HEADER,
+        )
+
+        with pytest.raises(
+            exceptions.AuthenticationFailed,
+            match=r"Incorrect API KEY format.",
+        ):
+            api_key_authentication().authenticate(request)
 
     def test_authenticate_invalid_request_with_expired_key(
         self, invalid_request_with_expired_api_key
@@ -109,3 +139,37 @@ class TestApiKeyAuthentication:
             )
 
         assert entity is None
+
+
+@api_view()
+@authentication_classes([APIKeyAuthentication, BasicAuthentication])
+@permission_classes([IsAuthenticated])
+def multi_auth_view(request):
+    return Response({"username": request.user.username})
+
+
+@pytest.mark.django_db
+class TestMultiAuthenticatorFallback:
+    pytestmark = pytest.mark.django_db
+
+    def test_falls_back_to_basic_auth_when_no_api_key_header_is_sent(self, user):
+        # Regression test: APIKeyAuthentication used to raise NotAuthenticated
+        # whenever no Api-Key header was present, which stopped DRF from
+        # trying any other authenticator listed after it. Combining it with
+        # another authentication class (here, BasicAuthentication) must work.
+        factory = APIRequestFactory()
+        credentials = base64.b64encode(b"narutos:12345").decode()
+        request = factory.get("/multi-auth/", HTTP_AUTHORIZATION=f"Basic {credentials}")
+
+        response = multi_auth_view(request)
+
+        assert response.status_code == 200
+        assert response.data["username"] == "narutos"
+
+    def test_rejects_when_neither_authenticator_matches(self):
+        factory = APIRequestFactory()
+        request = factory.get("/multi-auth/")
+
+        response = multi_auth_view(request)
+
+        assert response.status_code == 403


### PR DESCRIPTION
## Summary

`APIKeyParser.get_from_authorization` (`drf_simple_apikey/parser.py`) raised `NotAuthenticated` whenever the `Authorization` header was missing, and `AuthenticationFailed` whenever it didn't contain the configured keyword. DRF's authenticator contract expects `None` in both cases so it can try the next authentication class — raising instead stops the pipeline immediately (`rest_framework.request.Request._authenticate`), so any view combining `APIKeyAuthentication` with another authenticator (session, token, ...) hard-rejected requests that simply weren't using this scheme, even with perfectly valid credentials for the other scheme.

## Fix

- Return `None` when there's no `Authorization` header, or when it's present but doesn't start with `AUTHENTICATION_KEYWORD_HEADER` — neither case is an attempt to use this scheme.
- Only raise `AuthenticationFailed("Incorrect API KEY format.")` once the keyword *does* match but the value itself is malformed — matching the convention DRF's own `TokenAuthentication` uses.
- Switched from a single-space substring split (`authorization.split(f"{keyword} ")`) to whitespace tokenizing (`.split()`), which also fixes a latent bug where extra whitespace around the key (e.g. `"Api-Key  <key>"`, two spaces) silently became part of the decrypted value instead of being rejected.

## ⚠️ Behavior change

A request with no key **and no other matching authenticator configured** now reaches `permission_classes` as anonymous instead of failing at the authentication step. If `APIKeyAuthentication` is your only authentication class and you were relying on a missing key being rejected automatically, you now need a permission class (e.g. `IsActiveEntity`, since `AnonymousUser.is_active` is `False`) to actually reject it. Called this out explicitly in the CHANGELOG and updated the quickstart/authentication docs, since this is exactly the pattern the quickstart already recommends (`authentication_classes` + `permission_classes` together) — projects following it are unaffected.

Also had to fix the "Common failure responses" table in `getting-started.mdx` from the earlier docs PR, since the `No API key provided.` message no longer exists — that case is now silent (returns `None`) rather than producing a `detail` message.

Closes #104.

## Test plan
- [x] Updated the existing test that asserted `NotAuthenticated` was raised on a missing header to assert `None` instead.
- [x] New tests: missing header → `None`; different scheme's keyword (`Bearer ...`) → `None`; matching keyword but malformed value → raises `AuthenticationFailed`.
- [x] New end-to-end test combining `APIKeyAuthentication` with DRF's `BasicAuthentication` on one view, proving a request with valid Basic auth credentials and no `Api-Key` header now authenticates successfully (this is the exact scenario described in the issue).
- [x] `pytest` (45 passed, 3 skipped) and `TEST_WITH_ROTATION=1 pytest` (48 passed).
- [x] `black --check` on changed files.