### PR TITLE
Use DRF BaseAuthentication for APIKeyAuthentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 [Unreleased]
 ------------
+- **Changed:** `APIKeyAuthentication` now inherits from DRF's
+  `BaseAuthentication` instead of Django's `BaseBackend`, aligning the
+  authentication backend with Django REST Framework's authentication API and
+  ensuring compatibility with DRF authentication behavior. (#127)
 - Added: Opt-in `ENABLE_PER_KEY_SECRET` setting (default `False`). When enabled,
   new API keys carry a random per-key secret (SHA-256 hash stored, verified with
   a constant-time comparison), checked in addition to Fernet decryption

--- a/drf_simple_apikey/backends.py
+++ b/drf_simple_apikey/backends.py
@@ -8,12 +8,12 @@ import time
 import typing
 
 from django.conf import settings
-from django.contrib.auth.backends import BaseBackend
 from django.http import HttpRequest
 from django.utils.timezone import now
 from django.core.exceptions import ObjectDoesNotExist
 
 from rest_framework import exceptions
+from rest_framework.authentication import BaseAuthentication
 
 
 from drf_simple_apikey.crypto import get_crypto
@@ -24,7 +24,7 @@ from drf_simple_apikey.settings import package_settings
 logger = logging.getLogger(__name__)
 
 
-class APIKeyAuthentication(BaseBackend):
+class APIKeyAuthentication(BaseAuthentication):
     model = APIKey
     key_parser = APIKeyParser()
 

--- a/tests/test_api_authentication.py
+++ b/tests/test_api_authentication.py
@@ -4,7 +4,7 @@ import pytest
 
 from django.contrib.auth.models import User
 from rest_framework import exceptions
-from rest_framework.authentication import BasicAuthentication
+from rest_framework.authentication import BaseAuthentication, BasicAuthentication
 from rest_framework.decorators import (
     api_view,
     authentication_classes,
@@ -68,6 +68,10 @@ def api_key_authentication():
     from drf_simple_apikey.backends import APIKeyAuthentication
 
     return APIKeyAuthentication()
+
+
+def test_api_key_authentication_is_a_drf_auth_class():
+    assert issubclass(APIKeyAuthentication, BaseAuthentication)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

Replace Django's `BaseBackend` with DRF's `BaseAuthentication` for `APIKeyAuthentication`.

## Changes

- Update `APIKeyAuthentication` to inherit from `rest_framework.authentication.BaseAuthentication`.
- Add a characterization test verifying the correct base class.

## Testing

- [x] `pytest tests/test_api_authentication.py`