### PR TITLE
fix(backends): support IPv6 address validation in client IP extraction

### DIFF
--- a/drf_simple_apikey/backends.py
+++ b/drf_simple_apikey/backends.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import ipaddress
 import logging
 import secrets
 import time
@@ -37,7 +38,7 @@ class APIKeyAuthentication(BaseBackend):
     def _get_client_ip(self, request: HttpRequest) -> str | None:
         """
         Safely extract client IP address, handling proxy headers securely.
-        Validates IP format and falls back to REMOTE_ADDR.
+        Validates IP format (supports IPv4 and IPv6) and falls back to REMOTE_ADDR.
         """
         # First try the configured header
         ip_header = package_settings.IP_ADDRESS_HEADER
@@ -50,17 +51,13 @@ class APIKeyAuthentication(BaseBackend):
                 forwarded_ips = client_ip.split(",") if client_ip else []
                 client_ip = forwarded_ips[0].strip() if forwarded_ips else None
 
-        # Validate IP format (basic validation)
+        # Validate IP format (supports IPv4 and IPv6)
         if client_ip:
-            # Basic IP validation - check if it looks like an IP
-            parts = client_ip.split(".")
-            if len(parts) == 4:
-                try:
-                    # Validate each part is 0-255
-                    if all(0 <= int(part) <= 255 for part in parts):
-                        return client_ip
-                except (ValueError, AttributeError):
-                    pass
+            try:
+                ipaddress.ip_address(client_ip)
+                return client_ip
+            except (ValueError, TypeError):
+                pass
 
         # Fallback to REMOTE_ADDR
         return request.META.get("REMOTE_ADDR")

--- a/tests/test_ip_management.py
+++ b/tests/test_ip_management.py
@@ -108,3 +108,84 @@ class TestApiKeyAuthenticationWithIPManagement:
 
         entity, _ = api_key_authentication.authenticate(request)
         assert isinstance(entity, User)
+
+    def test_get_client_ip_ipv6(self, api_key_authentication, settings):
+        """Tests that IPv6 addresses are extracted and validated correctly."""
+        factory = APIRequestFactory()
+
+        # Direct REMOTE_ADDR IPv6
+        req1 = factory.get("/", REMOTE_ADDR="2001:db8::1")
+        assert api_key_authentication._get_client_ip(req1) == "2001:db8::1"
+
+        # Compressed loopback IPv6
+        req2 = factory.get("/", REMOTE_ADDR="::1")
+        assert api_key_authentication._get_client_ip(req2) == "::1"
+
+        # Proxy X-Forwarded-For with IPv6
+        old_header = package_settings.IP_ADDRESS_HEADER
+        package_settings.IP_ADDRESS_HEADER = "HTTP_X_FORWARDED_FOR"
+        try:
+            req3 = factory.get("/", HTTP_X_FORWARDED_FOR="2001:db8::1, 10.0.0.1", REMOTE_ADDR="127.0.0.1")
+            assert api_key_authentication._get_client_ip(req3) == "2001:db8::1"
+        finally:
+            package_settings.IP_ADDRESS_HEADER = old_header
+
+    def test_authenticate_valid_request_with_whitelisted_ipv6(
+        self, user, active_api_key, api_key_authentication
+    ):
+        """Tests that a request from a whitelisted IPv6 address is authenticated successfully."""
+        factory = APIRequestFactory()
+        api_key, key = active_api_key
+        api_key.whitelisted_ips = ["2001:db8::1"]
+        api_key.save()
+
+        request = factory.get(
+            "/test-request/",
+            REMOTE_ADDR="2001:db8::1",
+            HTTP_AUTHORIZATION=f"{package_settings.AUTHENTICATION_KEYWORD_HEADER} {key}",
+        )
+
+        entity, _ = api_key_authentication.authenticate(request)
+        assert isinstance(entity, User)
+
+    def test_authenticate_denied_for_blacklisted_ipv6(
+        self, user, active_api_key, api_key_authentication
+    ):
+        """Tests that a request from a blacklisted IPv6 address is denied."""
+        factory = APIRequestFactory()
+        api_key, key = active_api_key
+        api_key.blacklisted_ips = ["2001:db8::1"]
+        api_key.save()
+
+        request = factory.get(
+            "/test-request/",
+            REMOTE_ADDR="2001:db8::1",
+            HTTP_AUTHORIZATION=f"{package_settings.AUTHENTICATION_KEYWORD_HEADER} {key}",
+        )
+
+        with pytest.raises(
+            exceptions.AuthenticationFailed, match=r"Access denied from blacklisted IP."
+        ):
+            api_key_authentication.authenticate(request)
+
+    def test_authenticate_denied_for_unlisted_ipv6_with_existing_whitelist(
+        self, user, active_api_key, api_key_authentication
+    ):
+        """Tests that an unlisted IPv6 request is denied when a whitelist is active."""
+        factory = APIRequestFactory()
+        api_key, key = active_api_key
+        api_key.whitelisted_ips = ["2001:db8::1"]
+        api_key.save()
+
+        request = factory.get(
+            "/test-request/",
+            REMOTE_ADDR="2001:db8::999",
+            HTTP_AUTHORIZATION=f"{package_settings.AUTHENTICATION_KEYWORD_HEADER} {key}",
+        )
+
+        with pytest.raises(
+            exceptions.AuthenticationFailed,
+            match=r"Access restricted to specific IP addresses.",
+        ):
+            api_key_authentication.authenticate(request)
+


### PR DESCRIPTION
Fixes #105

## Proposed Changes
- Replace manual IPv4 octet splitting in `APIKeyAuthentication._get_client_ip` with Python's standard `ipaddress.ip_address()` validation.
- Supports IPv6 client IP addresses in direct (`REMOTE_ADDR`) and proxy (`HTTP_X_FORWARDED_FOR`) headers.
- Ensures IPv6 client addresses are properly validated and checked against `whitelisted_ips` and `blacklisted_ips`.
- Adds unit tests in `tests/test_ip_management.py` covering IPv6 extraction, whitelisting, and blacklisting.

## Verification
- Ran test suite with `pytest`: 57 passed, 3 skipped.